### PR TITLE
feat: add Adaptive Theme to Screen & Display section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,7 @@ LSPosed allows you to use Xposed modules, which are small add-ons that can modif
 
 ## Screen and Display
 
+- **[Adaptive Theme](https://github.com/xLexip/Adaptive-Theme)** - Uses the light sensor to auto-switch the system dark mode based on ambient light. `FOSS` | [▶️](https://play.google.com/store/apps/details?id=dev.lexip.hecate)
 - **[AlwaysOn](https://github.com/Domi04151309/AlwaysOn)** - Adds an always-on display with various customization options regarding watch face, behavior, and background. `FOSS` `[LSP]`
 - **[Anti Brightness Change](https://github.com/binarynoise/XposedModulets)** - Prevents every app from changing the screen brightness. `FOSS` `[LSP]` | [🌱](https://apt.izzysoft.de/fdroid/index/apk/com.programminghoch10.AntiBrightnessChange)
 - **[AutoNight](https://github.com/Chilly-Blaze/autonight)** - Controlling Android's Dark Mode through environmental brightness. `FOSS`


### PR DESCRIPTION
### What I'm Adding
- **Adaptive Theme** - Uses the light sensor to auto-switch the system dark mode based on ambient light.
- **Category**: Screen and Display
- **Framework**: Root App

### Checklist
- [x] Tested all links
- [x] App requires root access
- [x] No duplicates found
- [x] Correct format used
- [x] Placed in right category alphabetically
- [x] Added proper tags

### Links
- Primary: https://github.com/xLexip/Adaptive-Theme
- Source: https://github.com/xLexip/Adaptive-Theme
- Play Store: https://play.google.com/store/apps/details?id=dev.lexip.hecate