### PR TITLE
docs(README.md): add DSP AudioFix to Audio Configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ In a category/sub-category, apps are sorted in following order: `⭐ (Community-
 - **[XAudioCapture](https://github.com/Xposed-Modules-Repo/io.github.wzhy.xaudiocapture)** - Lets you capture any audio stream you desire, bypassing these restrictions. `Proprietary` `[LSP]`
 
 **Audio Configuration:**
+- **[DSP AudioFix](https://github.com/ahmed-alnassif/DSP-AudioFix)** - A simple fix for distorted audio on Xiaomi/MediaTek devices with Awinic smart amps. `FOSS` `[M]` `[K]`
 - **[Audio Misc Settings](https://github.com/Magisk-Modules-Alt-Repo/audio-misc-settings)** - For setting miscellaneous audio configuration values (media audio volume steps (100 steps), raising the resampling quality, disabling the effects framework, etc.) `FOSS` `[M]`
 - **[Audio SampleRate Changer](https://github.com/Magisk-Modules-Alt-Repo/audio-samplerate-changer)** - A Magisk module changing audio sample rates at the system-wide mixer for the best Hi-Fi experience. `FOSS` `[M]`
 - **[Hi-Res Audio Enabler](https://github.com/reiryuki/Hi-Res-Audio-Enabler-Magisk-Module)** - Enables high resolution 24 or 32-bit width audio output if device is supported. `FOSS` `[M]`


### PR DESCRIPTION
**What does this PR do?**
add DSP AudioFix to Audio Configuration section

**Type of change:**
- [x] New app/module addition

## Testing

**How have you tested this?**
```bash
# Look for successful start messages
dmesg | grep -i "aw.*start success" | tail -10

# Check the full DSP calibration flow
dmesg | grep -E "task.*9|aw882.*cali" -B 5 -A 5
```
Results:
```
[37633.550014] [T29086] [Awinic][6-0035]aw882xx_start_pa: start success
[37633.550523] [T24279] [Awinic][6-0034]aw882xx_start_pa: start success
```
A snippet of DSP calibration flow
```
[37633.549135] [T29086] [Awinic][6-0035]aw882xx_monitor_start: enter
[37633.549989] [T29086] [IPI][TASK_Q] process_message_in_queue(), ack back, task: 9, msg_id: 0x204, ack_type: 1, p1: 0x34, p2: 0x5, dma sz: 52, idx: 1024, hal sz: 0, wb sz: 0
[37633.550009] [T29086] [Awinic][6-0035]aw882xx_device_start: done
[37633.550014] [T29086] [Awinic][6-0035]aw882xx_start_pa: start success
```

**Test environment:**
- Device: Poco x6 pro
- Android version: 16 (AOSP)
- Root method: kernelSU

---

**By submitting this PR, I confirm:**
- [x] My contribution is my own work or properly attributed
- [x] I agree to license my contribution under the project's MIT license
- [x] I've read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
